### PR TITLE
Add build support for Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,21 @@ all: help
 
 .PHONY: all help config update
 
-COMPONENTS = all-targets analysis asmparser asmprinter bitreader bitwriter codegen core debuginfodwarf executionengine instrumentation interpreter ipo irreader linker mc mcjit objcarcopts option profiledata scalaropts support target
+COMPONENTS = all-targets analysis asmparser asmprinter bitreader bitwriter codegen core coroutines debuginfodwarf executionengine instrumentation interpreter ipo irreader linker mc mcjit objcarcopts option profiledata scalaropts support target
 
 VERSION=7.0.0
 VERSION_MAJOR=$(firstword $(subst ., ,$(VERSION)))
 
 SRCDIR=llvm-$(VERSION)
+UNAME_S:=$(shell uname -s)
 
 ifeq ($(BUILDDIR),)
-CONFIG=llvm-config-$(VERSION_MAJOR)
+	ifeq ($(UNAME_S),Darwin)
+	CONFIG=/usr/local/Cellar/llvm/$(VERSION)/bin/llvm-config
+	LDFLAGS=-L/usr/local/opt/libffi/lib -lffi
+	else
+	CONFIG=llvm-config-$(VERSION_MAJOR)
+	endif
 else
 CONFIG=$(BUILDDIR)/bin/llvm-config
 endif
@@ -38,7 +44,7 @@ config:
 	@echo "" >> llvm_config.go
 	@echo "// #cgo CPPFLAGS: $(shell $(CONFIG) --cppflags)" >> llvm_config.go
 	@echo "// #cgo CXXFLAGS: -std=c++11" >> llvm_config.go
-	@echo "// #cgo LDFLAGS: $(shell $(CONFIG) --ldflags --libs --system-libs $(COMPONENTS))" >> llvm_config.go
+	@echo "// #cgo LDFLAGS: $(shell $(CONFIG) --ldflags --libs --system-libs $(COMPONENTS)) $(LDFLAGS)" >> llvm_config.go
 	@echo "import \"C\"" >> llvm_config.go
 	@echo "" >> llvm_config.go
 	@echo "type (run_build_sh int)" >> llvm_config.go


### PR DESCRIPTION
This makes it possible to compile tinygo on macOS.

It assumes that llvm is installed via brew, instead of using the system provided llvm. This has the benefit of easily installing other llvm versions should tinygo requires a higher version of llvm in the future. Tinygo installation documentation should be updated for macOS to include this installation:
```bash
brew install llvm
```

While this PR leads to a successful build of tinygo, the compiler itself fails at runtime:
```
$ tinygo build -o /src/blinky.elf -target arduino /src/examples/blinky
error: No available targets are compatible with this triple.
```
